### PR TITLE
Configure the targetOrigin argument

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,6 +1,6 @@
 pipeline:
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: latest

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,6 +1,6 @@
 pipeline:
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: "${CI_COMMIT_TAG##v}"

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,6 +1,6 @@
 pipeline:
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       dry_run: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:3.16.0 as builder
+FROM madnificent/ember:3.28.5 as builder
 
 LABEL maintainer="info@redpencil.io"
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -12,7 +12,7 @@ export default class ApplicationRoute extends Route {
     const resizeObserver = new ResizeObserver((entries) => {
       let body = entries[0].target;
       let newHeight = body.clientHeight;
-      window.parent.postMessage({ height: newHeight });
+      window.parent.postMessage({ height: newHeight }, '*');
     });
 
     resizeObserver.observe(document.body);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@lblod/ember-vo-webuniversum": "^0.22.8",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.6.0",
+    "ember-auto-import": "^2.6.1",
     "ember-classic-decorator": "^1.0.8",
     "ember-cli": "~3.20.2",
     "ember-cli-app-version": "^3.2.0",
@@ -70,7 +70,8 @@
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.2.0",
     "sass": "^1.26.10",
-    "svgxuse": "^1.2.6"
+    "svgxuse": "^1.2.6",
+    "webpack": "^5.76.2"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
It seems we missed this in our previous PR. [`targetOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#parameters) is needed to make cross-domain messaging possible.

Since we're only sending the new height this isn't considered risky data and all origins are allowed to receive it.