### PR TITLE
Fix file downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN npm run build
 
 FROM semtech/ember-proxy-service:1.5.1
 
-ENV STATIC_FOLDERS_REGEX="^/(assets|font|files|@appuniversum)/"
+ENV STATIC_FOLDERS_REGEX="^/(assets|font|files|files-download|@appuniversum)/"
 
 COPY --from=builder /app/dist /app


### PR DESCRIPTION
We use the `/files-download` endpoint to trigger file downloads, but that endpoint wasn't added to the STATIC_FOLDERS_REGEX yet. As a result all downloads returned the index.html file instead.