### PR TITLE
Fix a validation regression

### DIFF
--- a/app/models/complaint-form.js
+++ b/app/models/complaint-form.js
@@ -18,10 +18,12 @@ export default class ComplaintForm extends Model {
 
 export const validationSchema = Joi.object({
   name: Joi.string()
+    .trim()
     .empty('')
     .required()
     .messages({ '*': 'Het veld Naam is verplicht.' }),
   street: Joi.string()
+    .trim()
     .empty('')
     .required()
     .messages({ '*': 'Het veld Straat is verplicht.' }),
@@ -31,6 +33,7 @@ export const validationSchema = Joi.object({
     .required()
     .messages({ '*': 'Het veld Huisnummer is verplicht.' }),
   locality: Joi.string()
+    .trim()
     .empty('')
     .required()
     .messages({ '*': 'Het veld Gemeente of Stad is verplicht.' }),
@@ -44,6 +47,7 @@ export const validationSchema = Joi.object({
       '*': 'Het veld Postcode moet een geldige postcode bevatten.',
     }),
   telephone: Joi.string()
+    .trim()
     .empty('')
     .regex(/^(tel:)?\+?[0-9]*$/)
     .messages({
@@ -54,6 +58,7 @@ export const validationSchema = Joi.object({
     '*': 'Het veld E-mailadres moet een geldig e-mailadres bevatten',
   }),
   content: Joi.string()
+    .trim()
     .empty('')
     .required()
     .messages({ '*': 'Het veld Omschrijving klacht is verplicht.' }),

--- a/tests/unit/models/complaint-form-test.js
+++ b/tests/unit/models/complaint-form-test.js
@@ -20,6 +20,7 @@ module('Unit | Model | complaint form', function (hooks) {
     assert.ok(result.errors.email, 'invalid email');
     assert.ok(result.errors.content, 'invalid content');
 
+    // Empty strings
     complaintForm.name = '';
     complaintForm.street = '';
     complaintForm.houseNumber = '';
@@ -31,7 +32,35 @@ module('Unit | Model | complaint form', function (hooks) {
 
     result = await validateRecord(complaintForm, validationSchema);
     assert.false(result.isValid, 'empty strings are ignored');
+    assert.ok(result.errors.name, 'invalid name');
+    assert.ok(result.errors.street, 'invalid street');
+    assert.ok(result.errors.houseNumber, 'invalid house number');
+    assert.ok(result.errors.locality, 'invalid locality');
+    assert.ok(result.errors.postalCode, 'invalid postal code');
+    assert.ok(result.errors.email, 'invalid email');
+    assert.ok(result.errors.content, 'invalid content');
 
+    // Whitespace-only values
+    complaintForm.name = ' ';
+    complaintForm.street = ' ';
+    complaintForm.houseNumber = ' ';
+    complaintForm.locality = ' ';
+    complaintForm.postalCode = ' ';
+    complaintForm.telephone = ' ';
+    complaintForm.email = ' ';
+    complaintForm.content = ' ';
+
+    result = await validateRecord(complaintForm, validationSchema);
+    assert.false(result.isValid, 'whitespace-only is not valid');
+    assert.ok(result.errors.name, 'invalid name');
+    assert.ok(result.errors.street, 'invalid street');
+    assert.ok(result.errors.houseNumber, 'invalid house number');
+    assert.ok(result.errors.locality, 'invalid locality');
+    assert.ok(result.errors.postalCode, 'invalid postal code');
+    assert.ok(result.errors.email, 'invalid email');
+    assert.ok(result.errors.content, 'invalid content');
+
+    // Valid values
     complaintForm.name = 'Jane Doe';
     complaintForm.street = 'Foostraat';
     complaintForm.houseNumber = '2';
@@ -45,6 +74,7 @@ module('Unit | Model | complaint form', function (hooks) {
     assert.true(result.isValid);
     assert.notOk(result.errors);
 
+    // Extra validation checks
     complaintForm.houseNumber = '2A';
     complaintForm.postalCode = '1000000000';
     complaintForm.email = 'foobar.be';


### PR DESCRIPTION
The previous implementation didn't consider whitespace as valid input values for the required fields. It seems that the `.empty('')` Joi validation isn't the full equivalent to get the same behaviour. We now also add a `.trim()` validator to restore the old behaviour.