### PR TITLE
Fix the telephone formatting helper

### DIFF
--- a/app/helpers/format-tel.js
+++ b/app/helpers/format-tel.js
@@ -33,6 +33,9 @@ export default function formatTel(tel) {
 
   const stripped = stripFormatting(tel);
 
+  // Our form doesn't trim the input yet, so it's possible users simply entered whitespace which we shouldn't try to format.
+  if (!stripped) return '';
+
   if (isShortNumber(stripped)) {
     // Short numbers don't require spaces
     return stripped;
@@ -143,9 +146,10 @@ function formatSpecialNumber(tel) {
  * @returns {string} Formatted string with digits grouped in twos.
  */
 function formatSeriesDigitsFree(digits) {
+  // TODO: We disable this check for now, since our form doesn't enforce a minimum of 4 characters
   // Throw an error if there are less than 4 digits
-  if (digits.length < 4)
-    throw new Error('Stopping because of fewer than 4 numbers');
+  // if (digits.length < 4)
+  //   throw new Error('Stopping because of fewer than 4 numbers');
 
   let input = digits;
   const output = [];

--- a/app/templates/complaints/index.gjs
+++ b/app/templates/complaints/index.gjs
@@ -93,9 +93,15 @@ export default class ComplaintsIndex extends Component {
               </td>
               <td>
                 {{#if complaint.telephone}}
-                  <AuLinkExternal href="tel:{{complaint.telephone}}">
-                    {{formatTel complaint.telephone}}
-                  </AuLinkExternal>
+                  {{#let (formatTel complaint.telephone) as |tel|}}
+                    {{#if tel.length}}
+                      <AuLinkExternal href="tel:{{complaint.telephone}}">
+                        {{formatTel complaint.telephone}}
+                      </AuLinkExternal>
+                    {{else~}}
+                      -
+                    {{~/if}}
+                  {{/let}}
                 {{else}}-{{/if}}
               </td>
               <td>

--- a/tests/integration/helpers/format-tel-test.js
+++ b/tests/integration/helpers/format-tel-test.js
@@ -107,6 +107,10 @@ module('Unit | Helper | format-tel', function () {
     assert.strictEqual(formatTel(''), '');
   });
 
+  test('it returns an empty string if only whitespace is provided', function (assert) {
+    assert.strictEqual(formatTel('    '), '');
+  });
+
   test('it asserts the correct amount of arguments', function (assert) {
     assert.throws(() => {
       formatTel();


### PR DESCRIPTION
We copied this helper from a different project which has stricter rules for the phone number field. We now make things more flexible to match our own validation rules.