### PR TITLE
[DL-6715] Improve file redirect flow

### DIFF
--- a/app/routes/file-redirect.js
+++ b/app/routes/file-redirect.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class FileRedirectRoute extends Route {
   @service router;
+  @service session;
   @service store;
 
   beforeModel(transition) {

--- a/app/routes/file-redirect.js
+++ b/app/routes/file-redirect.js
@@ -5,6 +5,10 @@ export default class FileRedirectRoute extends Route {
   @service router;
   @service store;
 
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition);
+  }
+
   async model(params) {
     const results = await this.store.query('complaint-form', {
       'filter[attachments][:id:]': params.id,

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -21,7 +21,21 @@ export default class SessionService extends BaseSessionService {
       ? 'acmidm-login'
       : 'mock-login';
 
-    return super.requireAuthentication(transition, loginRoute);
+    const isAuthenticated = super.requireAuthentication(transition, loginRoute);
+
+    // The user isn't authenticated. We store the url in a cookie so we can retry it after logging in.
+    if (!isAuthenticated) {
+      // By default ESA only supports retrying transitions by looking at the `attemptedTransition` property.
+      // However, this property isn't persisted, so after a page reload it is gone, which is an issue for our redirect-based ACM/IDM setup.
+      // ESA also has a cookie-based redirect setup to support FastBoot. With a little bit of code we can hook into this system
+      // so the redirect also survives a page reload.
+      // TODO: remove this once it's built into the addon: https://github.com/mainmatter/ember-simple-auth/issues/2808
+      const COOKIE_NAME = 'ember_simple_auth-redirectTarget'; // This is the name that ESA uses: https://github.com/mainmatter/ember-simple-auth/blob/1404c501c2ba9c8c6c071b05f38d42a057522318/packages/ember-simple-auth/src/-internals/routing.js#L37
+      const redirectUrl = routeInfoUrl(transition.to, this.router);
+      document.cookie = `${COOKIE_NAME}=${redirectUrl};path=/;samesite=strict`;
+    }
+
+    return isAuthenticated;
   }
 
   invalidate() {
@@ -39,4 +53,29 @@ export default class SessionService extends BaseSessionService {
 
     super.handleInvalidation(logoutUrl);
   }
+}
+
+// This converts a RouteInfo instance to the corresponding url by collecting all
+// the route params and query params and using the router.urlFor method.
+// This is a public API reimplementation of the `transition.intent.url` property.
+// More info: https://discord.com/channels/480462759797063690/624403666585124895/897832626616926218
+function routeInfoUrl(routeInfo, routerService) {
+  let targetRoute = routeInfo.name;
+  let allRouteParamValues = [];
+  let allRouteQueryParams = {};
+
+  routeInfo.find((routeInfo) => {
+    routeInfo.paramNames.forEach((paramName) => {
+      let paramValue = routeInfo.params[paramName];
+      allRouteParamValues.push(paramValue);
+      allRouteQueryParams = {
+        ...allRouteQueryParams,
+        ...routeInfo.queryParams,
+      };
+    });
+  });
+
+  return routerService.urlFor(targetRoute, ...allRouteParamValues, {
+    queryParams: allRouteQueryParams,
+  });
 }


### PR DESCRIPTION
This fixes some issues with the file download link redirect flow:

- Users who aren't logged in will be redirected to the login page instead of the error page
- Users will be redirected back to the original page they visited before they were redirected to the login page instead of to the overview page which means they don't need to click the link in their mail again.

**Test instructions**

- paste the file download link in your browser url bar when you are not logged in (can be found by logging in, copying the download link on the details page and replacing `files-download/id/download` with `/files/id/download`)
- verify that the user is redirected to the login page
- verify that the user is redirected to the correct complaint form details page after logging in instead of the overview page