### PR TITLE
Use the `semtech/static-file-service` as a base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,5 @@ RUN npm ci
 RUN npm run build
 
 
-FROM semtech/ember-proxy-service:1.5.1
-
-ENV STATIC_FOLDERS_REGEX="^/(assets|font|files|files-download|@appuniversum)/"
-
-COPY --from=builder /app/dist /app
+FROM semtech/static-file-service:0.2.0
+COPY --from=builder /app/dist /data


### PR DESCRIPTION
The `semtech/ember-proxy-service` image is deprecated.

Breaking since it requires changes in the way it is deployed:
- it assumes the identifier is the entry point
- dispatcher needs to redirect to the frontend when appropriate
- some dispatcher rules might need extra accept type checks if they overlap with frontend routes