### PR TITLE
Fix an issue with the login redirection logic

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,8 +1,11 @@
+import { service } from '@ember/service';
 import BaseSessionService from 'ember-simple-auth/services/session';
 import ENV from 'frontend-complaint-form/config/environment';
 import { isValidAcmidmConfig } from 'frontend-complaint-form/utils/acmidm';
 
 export default class SessionService extends BaseSessionService {
+  @service router;
+
   get isAcmIdmSession() {
     if (!this.isAuthenticated) {
       return false;


### PR DESCRIPTION
We forgot to inject the router service which is required for things to work. We didn't notice because the model hooks swallow exceptions and the redirect still works properly if the browser isn't refreshed since the original route is also stored in memory.

Follow up to #23 